### PR TITLE
Check boundary states and add iteration cap

### DIFF
--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -46,6 +46,7 @@ class Simulation {
     double iState = 0;                                                   ///< The current index of the next state.
     bool dropletsAtBifurcation = false;                                  ///< If one or more droplets are currently at a bifurcation. Triggers the usage of the maximal adaptive time step.
     bool enableMerging = true;                                           ///< If the droplet merging simulation should be performed.
+    uint maxIterations = 1000000;                                        ///< Maximum iterations performed before computations are aborted.
 
     /**
      * @brief Initializes the resistance model and the channel resistances of the empty channels.

--- a/tests/simulation/Results.tests.cpp
+++ b/tests/simulation/Results.tests.cpp
@@ -854,3 +854,69 @@ TEST(Results, mixedDirectionChannels) {
 
     ASSERT_EQ(result.resistanceModel, 0);
 }
+
+TEST(Results, noSink1) {
+    droplet::Simulator sim;
+
+    int nodeGroundId = -1;
+    int node0Id = 0;
+    int node1Id = 1;
+
+    auto flowRate = 3e-11;
+    auto pump = sim.addFlowRatePump(nodeGroundId, node0Id, flowRate);
+
+    auto cWidth = 100e-6;
+    auto cHeight = 30e-6;
+    auto cLength = 1000e-6;
+
+    auto c1 = sim.addChannel(node0Id, node1Id, cHeight, cWidth, cLength);
+    auto c2 = sim.addChannel(node1Id, nodeGroundId, cHeight, cWidth, cLength);
+
+    sim.addGround(nodeGroundId);
+
+    auto fluid0 = sim.addFluid(1e-3, 1e3);
+    auto fluid1 = sim.addFluid(3e-3, 1e3);
+    sim.setContinuousPhase(fluid0);
+
+    auto dropletVolume = 1.5 * cWidth * cWidth * cHeight;
+    auto droplet0 = sim.addDroplet(fluid1, dropletVolume, 0.0, c1, 0.5);
+
+    sim.checkChipValidity();
+
+    droplet::SimulationResult result = sim.simulate();
+
+    ASSERT_EQ(result.chip.name, "");
+}
+
+TEST(Results, noSink2) {
+    droplet::Simulator sim;
+
+    int nodeGroundId = -1;
+    int node0Id = 0;
+    int node1Id = 1;
+
+    auto flowRate = 3e-11;
+    auto pump = sim.addFlowRatePump(nodeGroundId, node0Id, flowRate);
+
+    auto cWidth = 100e-6;
+    auto cHeight = 30e-6;
+    auto cLength = 1000e-6;
+
+    auto c1 = sim.addChannel(node0Id, node1Id, cHeight, cWidth, cLength);
+    auto c2 = sim.addChannel(node1Id, nodeGroundId, cHeight, cWidth, cLength);
+
+    sim.addGround(nodeGroundId);
+
+    auto fluid0 = sim.addFluid(1e-3, 1e3);
+    auto fluid1 = sim.addFluid(3e-3, 1e3);
+    sim.setContinuousPhase(fluid0);
+
+    auto dropletVolume = 1.5 * cWidth * cWidth * cHeight;
+    auto droplet0 = sim.addDroplet(fluid1, dropletVolume, 0.1, c1, 0.5);
+
+    sim.checkChipValidity();
+
+    droplet::SimulationResult result = sim.simulate();
+
+    ASSERT_EQ(result.chip.name, "");
+}


### PR DESCRIPTION
Create BoundaryHeadEvent only when the boundary is in normal state. Prevents infinite loops for certain configurations, fixes #2